### PR TITLE
$H.keys: use Object.keys if available

### DIFF
--- a/src/desktop/hash.js
+++ b/src/desktop/hash.js
@@ -400,11 +400,15 @@ jindo.$H.prototype.keys = function() {
 	var keys = this["__jindo_sorted_index"];
 	
 	if(!keys){
-	    keys = [];
-    	for(var k in this._table) {
-    		if(this._table.hasOwnProperty(k))
-    			keys.push(k);
-    	}
+		if(Object.keys){
+			keys = Object.keys(this._table);
+		} else {
+			keys = [];
+			for (var k in this._table) {
+				if (this._table.hasOwnProperty(k))
+					keys.push(k);
+			}
+		}
 	}
 
 	return keys;

--- a/src/mobile/hash.js
+++ b/src/mobile/hash.js
@@ -400,10 +400,14 @@ jindo.$H.prototype.keys = function() {
     var keys = this["__jindo_sorted_index"];
     
     if(!keys){
-        keys = [];
-        for(var k in this._table) {
-            if(this._table.hasOwnProperty(k))
-                keys.push(k);
+        if(Object.keys){
+            keys = Object.keys(this._table);
+        } else {
+            keys = [];
+            for (var k in this._table) {
+                if (this._table.hasOwnProperty(k))
+                    keys.push(k);
+            }
         }
     }
 


### PR DESCRIPTION
Change jindo.$H.prototype.keys() to use Object.keys() which is ECMA5 specified feature if available to use. The Object.keys() method returns an array of a given object's own enumerable properties, in the same order as that provided by a for...in loop. 

Browser compatibility:
IE9+, Chrome5+, FF4+, Safari5+, Opera12+
