### PR TITLE
Cookie bug fix

### DIFF
--- a/src/desktop/cookie.js
+++ b/src/desktop/cookie.js
@@ -13,20 +13,21 @@ jindo.$Cookie = function() {
 	//-@@$Cookie-@@//
 	var cl = arguments.callee;
 	var cached = cl._cached;
-	
 	if (cl._cached) return cl._cached;
+	
+	var cache = jindo.$Jindo;
 	if(!(this instanceof cl)){
 		try{
-			jindo.$Jindo._maxWarn(arguments.length, 1,"$Cookie");
+			cache._maxWarn(arguments.length, 1,"$Cookie");
 			return (arguments.length > 0) ? new cl(arguments[0]) : new cl;
 		}catch(e){
 			if (e instanceof TypeError) { return null; }
 			throw e;
 		}
 	}
-	if (typeof jindo.$Jindo.isUndefined(cl._cached)) cl._cached = this;
+	if (typeof cache.isUndefined(cl._cached)) cl._cached = this;
 	
-	var oArgs = g_checkVarType(arguments, {
+	var oArgs = cache.checkVarType(arguments, {
 		"4voi" : [],
 		"4bln" : ["bURIComponent:Boolean"]
 	}, "$Cookie");
@@ -66,7 +67,8 @@ jindo.$Cookie.prototype.keys = function() {
  */
 jindo.$Cookie.prototype.get = function(sName) {
 	//-@@$Cookie.get-@@//
-	var oArgs = g_checkVarType(arguments, {
+	var cache = jindo.$Jindo;
+	var oArgs = cache.checkVarType(arguments, {
 		'4str' : [ 'sName:String+']
 	},"$Cookie#get");
 	var ca = document.cookie.split(/\s*;\s*/);


### PR DESCRIPTION
- jindo.$Jindo.XXX형태로 되어있는 코드를 전체적인 일관성을 위해
  var cache = jindo.$Jindo
  cache.XXX 형태로 변경

- g_checkVarType 의 경우 독립파일 내에 존재하지 않는 변수이므로 cache.checkVarType로 대체

- strict mode에 대응하기 위해
var cl = Cookie || arguments.callee; 형식을 통해 기명함수의 이름을 먼저 인식하고 기명함수가 지원하지 않는 구형 브라우저는 strict mode가 작동하지 않는 점을 이용함

- 단위 테스트결과 첨부
![screenshot_3](https://cloud.githubusercontent.com/assets/5790535/5900406/1cac4b2c-a5ac-11e4-9b28-c32702ed3bd4.png)